### PR TITLE
投稿一覧/詳細ページのレイアウト再編集

### DIFF
--- a/app/assets/stylesheets/comments.scss
+++ b/app/assets/stylesheets/comments.scss
@@ -1,3 +1,8 @@
+.comment-count {
+  margin-left: 5px;
+  border-bottom: solid 1px black;
+}
+
 .comment-box {
   padding: 0.5em 1em;
   margin: 1em 0;

--- a/app/assets/stylesheets/posts.scss
+++ b/app/assets/stylesheets/posts.scss
@@ -1,13 +1,15 @@
+// 投稿一覧ページ
 .list-top {
   text-align: center;
-  padding: 15px;
+  padding: 7px 0 20px 0;
+  border-bottom: solid 1px black;
 }
 
 .list-seach {
-  border-top: solid 1px black;
+  border-top: solid 1px #121213;
   border-left: solid 6px #121213;
-  padding-left: 28px;
-  padding-bottom: 10px;
+  border-right: solid 6px #121213;
+  padding: 7px 0 10px 28px;
   box-shadow: 0px 2px 3px rgba(0, 0, 0, 0.33);
   margin-bottom: 15px;
 }
@@ -15,9 +17,14 @@
 .user-post {
   padding: 1px;
   padding-left: 20px;
-  border-top: solid 1px black;
   border-left: solid 6px #266dc9;
+  border-bottom: double 8px rgb(202, 201, 201);
   box-shadow: 0px 2px 3px rgba(0, 0, 0, 0.33);
+}
+
+.post-title {
+  font-size: large;
+  font-weight: 600;
 }
 
 .post-btn :hover {
@@ -102,4 +109,41 @@
   border: 1px solid #333333;
   cursor: pointer;
   box-shadow: 3px 5px rgb(41, 41, 248);
+}
+
+// 投稿詳細ページ
+.detail-wrapper {
+  padding: 0.5em 1em;
+  margin: 1em 0;
+  border-left: solid 6px #266dc9;
+  border-bottom: double 8px rgb(202, 201, 201);
+  box-shadow: 0px 2px 3px rgba(0, 0, 0, 0.33);
+}
+
+.text-comments {
+  text-align: center;
+  border-bottom: solid 1px black;
+  padding-bottom: 15px;
+}
+
+.comment-create {
+  padding: 5px 0 10px 15px;
+  border-left: solid 6px #5bb7ae;
+  box-shadow: 0px 2px 3px rgba(0, 0, 0, 0.33);
+}
+
+.back-list :hover {
+  opacity: 1;
+  background-color: rgb(58, 58, 58);
+  color: white;
+}
+
+.back-btn {
+  color: rgb(247, 7, 7);
+  background-color: #f1f7f5;
+  border-radius: 5px;
+  opacity: 0.8;
+  padding: 5px 5px 5px 5px;
+  border: 1px solid #333333;
+  cursor: pointer;
 }

--- a/app/assets/stylesheets/tops.scss
+++ b/app/assets/stylesheets/tops.scss
@@ -6,7 +6,7 @@
   text-align: center;
 }
 
-.top-wrapper {
+.top-title {
   border-bottom: solid 2px black;
   color: rgb(51, 50, 50);
 }

--- a/app/views/comments/_index.html.erb
+++ b/app/views/comments/_index.html.erb
@@ -1,22 +1,22 @@
 <!---- コメント内容 ----->
-コメント数<%= comments.count %>件
-  <% comments.each do |comment| %>
-    <% unless comment.id.nil? %>
-      <div class="comment-container">
-        <div class="comment-box">           
-          <div class="comment-text">
-            <p> <%= comment.user.username %> <%= comment.created_at.strftime('%Y/%m/%d %H:%M:%S') %></p>
-            <div class="comment-entry">
-              <%= simple_format(h comment.content) %>
-              <% if comment.user == current_user %>
-                <%= link_to post_comment_path(comment.post_id, comment.id), method: :delete, remote: true, class: "comment_destroy" do %>
-                  <i class="fas fa-trash" style="color: black;"></i>
-                <% end %>
+<a class="comment-count">コメント数<%= comments.count %>件</a>
+<% comments.each do |comment| %>
+  <% unless comment.id.nil? %>
+    <div class="comment-container">
+      <div class="comment-box">           
+        <div class="comment-text">
+          <p> <%= comment.user.username %> <%= comment.created_at.strftime('%Y/%m/%d %H:%M:%S') %></p>
+          <div class="comment-entry">
+            <%= simple_format(h comment.content) %>
+            <% if comment.user == current_user %>
+              <%= link_to post_comment_path(comment.post_id, comment.id), method: :delete, remote: true, class: "comment_destroy" do %>
+                <i class="fas fa-trash" style="color: black;"></i>
               <% end %>
-            </div>
+            <% end %>
           </div>
         </div>
       </div>
-    <% end %>
+    </div>
   <% end %>
-</div>
+<% end %>
+

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -1,6 +1,6 @@
 <div class="user-post">
-  <p>【投稿者】 <%= post.user.username %></p>
-  <p>【タイトル】 <%= post.title %></p>
+  <p>投稿者： <%= post.user.username %></p>
+  タイトル：<a class="post-title"><%= post.title %></a>
   <p id="post-<%= post.id %>">
     <% if post.liked_by?(current_user) %>
       <%= render "like", post: post %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,6 +1,6 @@
 <h1 class="list-top">投稿一覧</h1>
 <div class="list-seach">
-  <h3>キーワードを検索する</h3>
+  <h3>キーワードで検索</h3>
   <%= search_form_for @q do |f| %>
     <%= f.search_field :title_cont, placeholder: "タイトルで検索", autocomplete: "title_cont" %>
     <%= f.search_field :content_cont, placeholder: "内容で検索", autocomplete: "content_cont" %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,25 +1,27 @@
 <!-- 投稿内容 -->
-<h1>投稿詳細</h1>
-<p>【名前】 <%= @post.user.username %></p>
-<p>【タイトル】 <%= @post.title %></p>
-<p>【内容】 <%= simple_format(h @post.content) %></p>
-<p><%= @post.created_at.strftime('%Y/%m/%d %H:%M:%S') %></p>
-<p id="post-<%= @post.id %>">
-  <% if @post.liked_by?(current_user) %>
-    <%= render "like", post: @post %>
-  <% else %>
-    <%= render "dislike", post: @post %>
-  <% end %>
-</p>
+<h1 class="list-top">投稿詳細</h1>
+<div class="detail-wrapper">
+  <p><%= @post.user.username %> <%= @post.created_at.strftime('%Y/%m/%d %H:%M:%S') %></p>
+  <a class="post-title"><%= @post.title %></a>
+  <p><%= simple_format(h @post.content) %></p>
 
-<!-- 投稿編集と削除 -->
-<% if current_user.id == @post.user_id %>
-  <p>
-    <%= link_to "編集", edit_post_path(@post) %>
-    <%= link_to "削除", post_path(@post), method: :delete, data: { confirm: "削除しますか？" } %>
+  <p id="post-<%= @post.id %>">
+    <% if @post.liked_by?(current_user) %>
+      <%= render "like", post: @post %>
+    <% else %>
+      <%= render "dislike", post: @post %>
+    <% end %>
   </p>
-<% end %>
-<p><%= link_to "投稿一覧へ", posts_path %></p>
+
+  <!-- 投稿編集と削除 -->
+  <% if current_user.id == @post.user_id %>
+    <p class="post-btn">
+      <%= link_to "編集", edit_post_path(@post), class:"post-edit" %>
+      <%= link_to "削除", post_path(@post), method: :delete, data: { confirm: "削除しますか？" }, class:"delete" %>
+    </p>
+  <% end %>
+</div>
+<p class="back-list"><%= link_to "投稿一覧へ", posts_path, class:"back-btn" %></p>
 
 <!-- コメント一覧 -->
 <div class="row">
@@ -30,14 +32,10 @@
     </div>
   <% end %>
   <hr>
-  <ul>
-    <li class="comment-create">
-      <h3 class="text-left title">コメント一覧</h3>
-    </li>
-  </ul>
+    <h2 class="text-comments">コメント一覧</h2>
   <div class="comments_area">
     <%= render partial: 'comments/index', locals: { comments: @comments } %>
   </div>
 </div>
 
-<p><%= link_to "投稿一覧へ", posts_path %></p>
+<p class="back-list"><%= link_to "投稿一覧へ", posts_path, class:"back-btn" %></p>

--- a/app/views/tops/index.html.erb
+++ b/app/views/tops/index.html.erb
@@ -4,7 +4,7 @@
   </header>
   <div class="all-warapper">
     <div class="top-container">
-      <div class="top-wrapper">
+      <div class="top-title">
         <h1>おうち時間〜spendtime〜</h1>
       </div>
     </div>

--- a/app/views/tops/show.html.erb
+++ b/app/views/tops/show.html.erb
@@ -1,6 +1,6 @@
 <div class="all-warapper">
   <div class="top-container">
-    <div class="top-wrapper">
+    <div class="top-title">
       <h1>マイページ</h1>
     </div>
   </div>


### PR DESCRIPTION
## 実装内容
- 投稿一覧/詳細ページのレイアウト再編集
  - クラス名の `post-wrapper` を `post-title` に変更