### PR TITLE
adminにユーザーとコメントを追加/不要なクラスを削除

### DIFF
--- a/app/admin/comments.rb
+++ b/app/admin/comments.rb
@@ -1,0 +1,17 @@
+ActiveAdmin.register Comment do
+  # See permitted parameters documentation:
+  # https://github.com/activeadmin/activeadmin/blob/master/docs/2-resource-customization.md#setting-up-strong-parameters
+  #
+  # Uncomment all parameters which should be permitted for assignment
+  #
+  # permit_params :content, :user_id, :post_id
+  #
+  # or
+  #
+  # permit_params do
+  #   permitted = [:content, :user_id, :post_id]
+  #   permitted << :other if params[:action] == 'create' && current_user.admin?
+  #   permitted
+  # end
+  permit_params :content
+end

--- a/app/admin/users.rb
+++ b/app/admin/users.rb
@@ -1,0 +1,18 @@
+ActiveAdmin.register User do
+
+  # See permitted parameters documentation:
+  # https://github.com/activeadmin/activeadmin/blob/master/docs/2-resource-customization.md#setting-up-strong-parameters
+  #
+  # Uncomment all parameters which should be permitted for assignment
+  #
+  # permit_params :email, :encrypted_password, :reset_password_token, :reset_password_sent_at, :remember_created_at, :username
+  #
+  # or
+  #
+  # permit_params do
+  #   permitted = [:email, :encrypted_password, :reset_password_token, :reset_password_sent_at, :remember_created_at, :username]
+  #   permitted << :other if params[:action] == 'create' && current_user.admin?
+  #   permitted
+  # end
+  permit_params :username, :email, :password
+end

--- a/app/views/comments/_index.html.erb
+++ b/app/views/comments/_index.html.erb
@@ -2,20 +2,14 @@
 <a class="comment-count">コメント数<%= comments.count %>件</a>
 <% comments.each do |comment| %>
   <% unless comment.id.nil? %>
-    <div class="comment-container">
-      <div class="comment-box">           
-        <div class="comment-text">
-          <p> <%= comment.user.username %> <%= comment.created_at.strftime('%Y/%m/%d %H:%M:%S') %></p>
-          <div class="comment-entry">
-            <%= simple_format(h comment.content) %>
-            <% if comment.user == current_user %>
-              <%= link_to post_comment_path(comment.post_id, comment.id), method: :delete, remote: true, class: "comment_destroy" do %>
-                <i class="fas fa-trash" style="color: black;"></i>
-              <% end %>
-            <% end %>
-          </div>
-        </div>
-      </div>
+    <div class="comment-box">           
+      <p> <%= comment.user.username %> <%= comment.created_at.strftime('%Y/%m/%d %H:%M:%S') %></p>
+      <%= simple_format(h comment.content) %>
+      <% if comment.user == current_user %>
+        <%= link_to post_comment_path(comment.post_id, comment.id), method: :delete, remote: true, class: "comment_destroy" do %>
+          <i class="fas fa-trash" style="color: black;"></i>
+        <% end %>
+      <% end %>
     </div>
   <% end %>
 <% end %>

--- a/config/initializers/active_admin.rb
+++ b/config/initializers/active_admin.rb
@@ -332,4 +332,6 @@ ActiveAdmin.setup do |config|
   # You can switch to using Webpacker here.
   #
   # config.use_webpacker = true
+
+  config.comments_registration_name = "AdminComment"
 end


### PR DESCRIPTION
## 実装内容
- `admin` にユーザーとコメントを追加
  - ユーザー側のコメントは `comment`とする
  - `admin` 側のコメントは `AdminComment` とする

- 不要なクラスを削除
  - CSSで使用していないクラスの削除