### PR TITLE
ページネーションのレイアウト/ヘッダーに投稿リンク追加

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -43,6 +43,36 @@
   background-color: blue;
 }
 
+// kaminari
+.paginate-btn {
+  text-align: center;
+  margin-bottom: 8px;
+}
+
+.current {
+  color: blue;
+
+  margin-right: 5px;
+  text-shadow: 1px 0 6px green;
+}
+
+.pages-btn :hover {
+  opacity: 1;
+  background-color: rgb(60, 60, 253);
+  transition: 0.3s;
+}
+
+.pages {
+  color: white;
+  background-color: #6da7ff;
+  padding: 5px 5px;
+  text-shadow: 1px 0 5px black;
+  border-radius: 5px;
+  opacity: 0.8;
+  border: 1px solid #333333;
+  cursor: pointer;
+}
+
 // スマホ用
 @media (max-width: 767px) {
   // tops/index.html

--- a/app/assets/stylesheets/layouts.scss
+++ b/app/assets/stylesheets/layouts.scss
@@ -22,6 +22,16 @@
   border: 1px solid #333333;
 }
 
+.header-post {
+  color: white;
+  background-color: #4ca084;
+  text-shadow: 1px 0 5px black;
+  border-radius: 5px;
+  opacity: 0.8;
+  padding: 10px;
+  border: 1px solid #333333;
+}
+
 .header-mypage {
   color: white;
   background-color: #4ca084;

--- a/app/assets/stylesheets/posts.scss
+++ b/app/assets/stylesheets/posts.scss
@@ -155,11 +155,6 @@
   color: black;
 }
 
-.paginate-btn {
-  text-align: center;
-  color: blue;
-}
-
 // 新規投稿ページ
 .area-field {
   resize: none;

--- a/app/views/kaminari/_first_page.html.erb
+++ b/app/views/kaminari/_first_page.html.erb
@@ -1,0 +1,11 @@
+<%# Link to the "First" page
+  - available local variables
+    url:           url to the first page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="pages-btn">
+  <%= link_to_unless current_page.first?, t('views.pagination.first').html_safe, url, remote: remote, class: "pages" %>
+</span>

--- a/app/views/kaminari/_gap.html.erb
+++ b/app/views/kaminari/_gap.html.erb
@@ -1,0 +1,8 @@
+<%# Non-link tag that stands for skipped pages...
+  - available local variables
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="page gap"><%= t('views.pagination.truncate').html_safe %></span>

--- a/app/views/kaminari/_last_page.html.erb
+++ b/app/views/kaminari/_last_page.html.erb
@@ -1,0 +1,11 @@
+<%# Link to the "Last" page
+  - available local variables
+    url:           url to the last page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="pages-btn">
+  <%= link_to_unless current_page.last?, t('views.pagination.last').html_safe, url, remote: remote, class: "pages" %>
+</span>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -1,0 +1,11 @@
+<%# Link to the "Next" page
+  - available local variables
+    url:           url to the next page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="pages-btn">
+  <%= link_to_unless current_page.last?, t('views.pagination.next').html_safe, url, rel: 'next', remote: remote, class: "pages" %>
+</span>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -1,0 +1,12 @@
+<%# Link showing page number
+  - available local variables
+    page:          a page object for "this" page
+    url:           url to this page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="pages-btn<%= ' current' if page.current? %>">
+  <%= link_to_unless page.current?, page, url, {remote: remote, rel: page.rel, class: "pages"} %>
+</span>

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -1,0 +1,25 @@
+<%# The container tag
+  - available local variables
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+    paginator:     the paginator that renders the pagination tags inside
+-%>
+<%= paginator.render do -%>
+  <nav class="pagination" role="navigation" aria-label="pager">
+    <%= first_page_tag unless current_page.first? %>
+    <%= prev_page_tag unless current_page.first? %>
+    <% each_page do |page| -%>
+      <% if page.display_tag? -%>
+        <%= page_tag page %>
+      <% elsif !page.was_truncated? -%>
+        <%= gap_tag %>
+      <% end -%>
+    <% end -%>
+    <% unless current_page.out_of_range? %>
+      <%= next_page_tag unless current_page.last? %>
+      <%= last_page_tag unless current_page.last? %>
+    <% end %>
+  </nav>
+<% end -%>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -1,0 +1,11 @@
+<%# Link to the "Previous" page
+  - available local variables
+    url:           url to the previous page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="pages-btn">
+  <%= link_to_unless current_page.first?, t('views.pagination.previous').html_safe, url, rel: 'prev', remote: remote, class: "pages" %>
+</span>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -3,6 +3,7 @@
     <div class="header-right">
       <% if user_signed_in? %>
         <%= link_to "TOPへ", root_path, class:"header-top" %>
+        <%= link_to "投稿", new_post_path, class:"header-post" %>
         <%= link_to "マイページ", mypage_path(current_user), class:"header-mypage" %>
       <% else %>
         <%= link_to "TOPへ", root_path, class:"header-top" %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -27,6 +27,6 @@ ja:
     pagination:
       first: '最初'
       last: '最後'
-      previous: '前のページへ'
-      next: '次のページへ'
+      previous: '前へ'
+      next: '次へ'
       truncate: '...'


### PR DESCRIPTION
## 実装内容
- ページネーションのレイアウト変更
  - `kaminari` の `view` ファイルを作成

- `header` に投稿リンクを追加
  - ログイン済みの場合 `header` の「投稿」から投稿画面に遷移できるよう実装